### PR TITLE
Fixed header not spanning whole width

### DIFF
--- a/framework/Settings.tex
+++ b/framework/Settings.tex
@@ -1,3 +1,11 @@
+% page margins
+\geometry{
+  left=2.5cm,
+  right=2.5cm,
+  top=2.5cm,
+  bottom=3cm
+}
+
 % Disable single lines at the start of a paragraph (Schusterjungen)
 \clubpenalty=10000
 
@@ -100,14 +108,6 @@
 \settowidth{\cftlistingsnumwidth}{\cftlistingspresnum}
 \addtolength{\cftlistingsnumwidth}{1cm}
 \setlength{\cftlistingsindent}{0cm}
-
-% page margins
-\geometry{
-  left=2.5cm,
-  right=2.5cm,
-  top=2.5cm,
-  bottom=3cm
-}
 
 \setlength{\parindent}{0cm}                             % Don't indent start of paragraph
 \setlength{\parskip}{6pt}                               % Lines are seperated by 6pt


### PR DESCRIPTION
Issue with header not spanning whole width due to geometry being set after fancyhdr.