### PR TITLE
fix: make clean target work under Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,9 @@
 .DEFAULT_GOAL := recompile_latex
 
-# Powershell clean commands
+# Windows cmd clean commands
 ifeq ($(OS),Windows_NT)
-	SHELL := powershell.exe
-	.SHELLFLAGS := -NoProfile -Command 
-	CLEAN_AUX +=-Get-ChildItem * -Include *.aux -Recurse | Remove-Item
-	CLEAN_IDX +=-Get-ChildItem * -Include *.acn,*.acr,*.alg,*.bbl,*.blg, \
-	            *.glg,*.glo,*.gls,*.glsdefs,*.idx,*.ilg,*.ist,*.listing,*.lof,*.log, \
-	            *.lol,*.lot,*.nlo,*.nls,*.out,*.tdo,*.toc -Recurse | Remove-Item
+	CLEAN_AUX = del /s *.aux
+	CLEAN_IDX = del /s *.acn *.acr *.alg *.bbl *.blg *.glg *.glo *.gls *.glsdefs *.idx *.ilg *.ist *.listing *.lof *.log *.lol *.lot *.nlo *.nls *.out *.tdo *.toc 
 
 # Unix clean commands
 else

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 # Powershell clean commands
 ifeq ($(OS),Windows_NT)
+	SHELL := powershell.exe
+	.SHELLFLAGS := -NoProfile -Command 
 	CLEAN_AUX +=-Get-ChildItem * -Include *.aux -Recurse | Remove-Item
 	CLEAN_IDX +=-Get-ChildItem * -Include *.acn,*.acr,*.alg,*.bbl,*.blg, \
 	            *.glg,*.glo,*.gls,*.glsdefs,*.idx,*.ilg,*.ist,*.listing,*.lof,*.log, \


### PR DESCRIPTION
`make clean` does not work because the `Get-ChildItem` command is only available in PowerShell, but windows uses CMD as default. With my change I instruct make to use PowerShell under Windows instead.