### PR TITLE
fix: adjust the header to also work for long titles

### DIFF
--- a/framework/Header.tex
+++ b/framework/Header.tex
@@ -1,23 +1,24 @@
 \centering
 \includegraphics[width=.8\textwidth]{framework/Logo_HS_Coburg}
+\vspace{\stretch{1}}
 
 \begin{Large}
   Hochschule für angewandte Wissenschaften Coburg\\
   Fakultät Elektrotechnik und Informatik\par
 \end{Large}
-\vspace{1.5cm}
+\vspace{\stretch{1.5}}
 
 \Large{Studiengang: \Studiengang}
-\vspace{1.5cm}
+\vspace{\stretch{1.5}}
 
 \Large{\DocumentType}
-\vspace{1cm}
+\vspace{\stretch{1}}
 
 \Huge{\Titel}
-\vspace{2cm}
+\vspace{\stretch{2}}
 
 \huge{\Autorenname}
-\vspace{2cm}
+\vspace{\stretch{2}}
 
 \Large{Abgabe der Arbeit: \Abgabe}
 


### PR DESCRIPTION
Problem
---------
Due to the hard-coded spacing, the lower part of the header was previously moved to another page for longer titles. This is not a desirable behavior and requires manual adjustment of the spacing by the template user. 

Solution
---------
As much vertical space as possible is used in these places, whereby the ratios between the spacings have not been changed.