### PR TITLE
Referencing cited authors in the text: Suggestion for using biblatex 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@
 *.tdo
 *.toc
 .vscode/*
+*.run.xml
 *.bcf

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 *.out
 *.tdo
 *.toc
+.vscode/*
+*.bcf

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ endif
 all:
 	@-pdflatex Arbeit && makeglossaries Arbeit && \
 	 makeindex Arbeit.nlo -s nomencl.ist -o Arbeit.nls && \
-	 pdflatex Arbeit && bibtex Arbeit & \
+	 pdflatex Arbeit && biber Arbeit & \
 	 pdflatex Arbeit && pdflatex Arbeit
 	@$(CLEAN_AUX)
 

--- a/Sektionen/Einfuehrung.tex
+++ b/Sektionen/Einfuehrung.tex
@@ -1,3 +1,4 @@
-\section{Einführung}
-
-Text ab hier \ldots
+\selectlanguage{ngerman}
+\section{Einleitung}\label{ch:Einleitung}
+Text ab hier \ldots \\
+Der Autor des Zitats \cite{Papula2006} heißt \citeauthor{Papula2006}.

--- a/framework/Environments.tex
+++ b/framework/Environments.tex
@@ -145,10 +145,9 @@
   % Bibliography
   \iftotalcountcitations
     \newpage
-    \bibliographystyle{alphadin}
     \phantomsection
     \addcontentsline{toc}{section}{\refname}
-    \bibliography{Verzeichnisse/Literaturverzeichnis}
+    \printbibliography
   \fi
 
   % Glossary

--- a/framework/Packages.tex
+++ b/framework/Packages.tex
@@ -62,6 +62,13 @@
   translate=babel
 ]{glossaries}
 
+% citation with biblatex
+\usepackage[
+  backend=biber,
+  style=alphabetic,
+  url = false,
+]{biblatex}
+
 % Track the total count of different environments
 % Needs to be imported because LaTeX resets these counter on a chapter basis
 \usepackage[figure,table,lstlisting,xspace]{totalcount}

--- a/framework/Settings.tex
+++ b/framework/Settings.tex
@@ -78,6 +78,12 @@
   \def\subsubsectionautorefname{Unterabschnitt}%                 3rd level sections should be called "Unterabschnitt"
 }
 
+% Bibliography
+\addbibresource{Verzeichnisse/Literaturverzeichnis.bib}
+\DefineBibliographyStrings{ngerman}{
+  andothers = {{et\,al\adddot}},
+}
+
 % -------------------------------------------------------------------
 %                        Code listing setup
 % -------------------------------------------------------------------


### PR DESCRIPTION
Problem
---------
I sometimes find it useful to include authors' names in the text, such as "Wie von Müller et al. beschrieben, ist die Erde rund.". With bibtex (as far as I know) it is not possible to do this dynamically and you would have to write out the name yourself.

Solution
---------
With biber and biblatex this is possible because in addition to the normal `\cite{xyz}` command, there is also the command `\citeauthor{xyz}`, which displays the name(s) of the author(s).