### PR TITLE
Makefile: Windows compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,9 @@ ARGS_PDFLATEX := -output-directory=$(BUILD_DIR) --shell-escape
 # Generate build directory (including child directories) if non-existant
 $(BUILD_DIR):
 ifeq ($(OS),Windows_NT)
-	powershell -Command "Get-ChildItem -Directory -Exclude '.git' | ForEach-Object { New-Item -ItemType Directory -Force -Path "${BUILD_DIR}" -Name $$_.Name }"	
+	powershell -Command "Get-ChildItem -Directory -Exclude '.*' | ForEach-Object { New-Item -ItemType Directory -Force -Path "${BUILD_DIR}" -Name $$_.Name }"	
 else
-	@for DIR in $(shell find . -maxdepth 1 -mindepth 1 -type d -not -name '.git' -exec basename '{}' \;); do \
+	@for DIR in $(shell find . -maxdepth 1 -mindepth 1 -type d -not -name '.*' -exec basename '{}' \;); do \
 		mkdir -p ${BUILD_DIR}/$$DIR; \
 	done
 endif


### PR DESCRIPTION
I've made updates to the Makefile to enable compatibility with Windows environments. Now, the build process should work on Windows. This should fix issue #11. 

Note my suggestions from pull request #9 and #10. If all are accepted there will be conflicts with the Makefile as they have been changed differently. In the new Makefile version only `bibtex` has to be replaced by `biber`, to merge #10. Regarding #9, I have already added the `--shell-escape` parameter to `pdflatex` as it does not break anything.