### PR TITLE
Add GitHub Action workflow to build the document

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -1,0 +1,69 @@
+name: LaTeX Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+    tags:
+      - "v*"
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Check Out Code
+        uses: actions/checkout@v3
+
+      - name: Install Texlive Apt Dependencies
+        uses: Eeems-Org/apt-cache-action@v1.1
+        with:
+          packages: texlive-full inkscape
+
+      - name: Build LaTeX Document
+        run: make all
+        shell: bash
+
+      - name: Check if Arbeit.pdf exists
+        run: |
+          if [ ! -f "Arbeit.pdf" ]; then
+            echo "Arbeit.pdf was not found. For the diagnosis of possible errors, see previous output."
+            exit 1
+          fi
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: Arbeit
+          path: Arbeit.pdf
+
+      - name: Set Tag
+        id: set_tag
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: echo "TAG=$(echo $GITHUB_REF | sed 's/refs\/tags\///')" >> $GITHUB_ENV
+
+      - name: Create Release
+        id: create_release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.TAG }}
+          release_name: Release ${{ env.TAG }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        if: steps.create_release.outputs.upload_url != ''
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: Arbeit.pdf
+          asset_name: Arbeit_${{ env.TAG }}.pdf
+          asset_content_type: application/pdf


### PR DESCRIPTION
I've created a GitHub Actions workflow to build the PDF file to further automate the build process. 

Reason
--------
I see two reasons or advantages for this. 

1. Firstly, no files that can be generated or downloaded in any other way should normally be part of the repository. In my view, this also includes the generated PDF file. In addition, this option still allows tracking of the various versions during document creation.
2. Another point is that users of the template who (for whatever reason) do not have texlive and inkscape installed can still create files. 

Solution
---------
The workflow is executed automatically for every push and pull request to the main branch. The workflow can also be triggered manually in the GitHub web interface. 

The workflow runs on an ubuntu on which texlive and inkscape are installed. The Makefile is used to build the document. If the process fails (e.g. due to errors in the LaTeX code), the workflow is terminated. (GitHub sends the user a notification about this by default).  
Once the PDF file has been created, it is attached to the workflow as an artifact. This can be downloaded by the user in the web interface if required.
If a tag is pushed that starts with "v" (e.g. "v1.02.03"), a GitHub release is created with the PDF file that contains the name of the tag.

Note
-----
For a reason I could not understand (but did not investigate further) the workflow does not work with the old Makefile ([main 32d67ca](https://github.com/btoschek/hsc-template/tree/32d67caf85e8890d980e6ae7b1440953e18a4adf)), although the old Makefile works correctly in a WSL Ubuntu on my local machine. Since this workflow works with the new Makefile [makefile-rework cd0be52](https://github.com/btoschek/hsc-template/tree/cd0be5255fbfec8ab5263117ca0cb8b7d55ad140), I create this pull request on the makefile-rework branch.
